### PR TITLE
AgensGraph custom port bug was fixed

### DIFF
--- a/src/connection/AgensGraphConnectionProvider.ts
+++ b/src/connection/AgensGraphConnectionProvider.ts
@@ -19,6 +19,7 @@ export class AgensGraphConnectionProvider implements ConnectionProvider {
     ) {
         this.pool = new AgensGraph.Pool({
             host: this.host,
+            port: this.port,
             user: this.user,
             password: this.password,
             database: this.database,


### PR DESCRIPTION
I found that port configuration wasn't used in AgensGraphConnectionProvider.