### PR TITLE
Reworked localStorage to use AsyncLocalStorage API

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register/transpile-only node_modules/.bin/jest --runInBand --detectOpenHandles",
         "test:unit": "jest --coverage --testPathPattern '1[.]Unit[/]'",
         "test:integration": "jest --coverage --testPathPattern '2[.]Integration[/]'",
-        "test:e2e": "jest --coverage --testPathPattern '3[.]EndToEnd[/]'"
+        "test:e2e": "jest --coverage --testPathPattern '3[.]EndToEnd[/]'",
+        "prepare": "npm run build"
     },
     "peerDependencies": {
         "@liberation-data/agensgraph": "^0.1.0-rc",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "client"
     ],
     "files": [
-        "**/*"
+        "dist/**/*"
     ],
     "main": "index.js",
     "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "client"
     ],
     "files": [
-        "dist/**/*"
+        "**/*"
     ],
     "main": "index.js",
     "types": "index.d.ts",
@@ -47,7 +47,7 @@
         "test:unit": "jest --coverage --testPathPattern '1[.]Unit[/]'",
         "test:integration": "jest --coverage --testPathPattern '2[.]Integration[/]'",
         "test:e2e": "jest --coverage --testPathPattern '3[.]EndToEnd[/]'",
-        "prepare": "npm run build"
+        "prepare": "npm run build && mkdir original && find . -maxdepth 1 | grep -v -e dist -e original -e node_modules -e '^.$' | xargs -i mv {} ./original && mv dist/* ."
     },
     "peerDependencies": {
         "@liberation-data/agensgraph": "^0.1.0-rc",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register/transpile-only node_modules/.bin/jest --runInBand --detectOpenHandles",
         "test:unit": "jest --coverage --testPathPattern '1[.]Unit[/]'",
         "test:integration": "jest --coverage --testPathPattern '2[.]Integration[/]'",
-        "test:e2e": "jest --coverage --testPathPattern '3[.]EndToEnd[/]'",
-        "prepare": "npm run build"
+        "test:e2e": "jest --coverage --testPathPattern '3[.]EndToEnd[/]'"
     },
     "peerDependencies": {
         "@liberation-data/agensgraph": "^0.1.0-rc",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "test:unit": "jest --coverage --testPathPattern '1[.]Unit[/]'",
         "test:integration": "jest --coverage --testPathPattern '2[.]Integration[/]'",
         "test:e2e": "jest --coverage --testPathPattern '3[.]EndToEnd[/]'",
-        "prepare": "npm run build && mkdir original && find . -maxdepth 1 | grep -v -e dist -e original -e node_modules -e '^.$' | xargs -i mv {} ./original && mv dist/* ."
+        "prepare": "npm run build"
     },
     "peerDependencies": {
         "@liberation-data/agensgraph": "^0.1.0-rc",

--- a/src/transaction/TransactonContextHolder.ts
+++ b/src/transaction/TransactonContextHolder.ts
@@ -2,9 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { TransactionContextKeys } from '@/transaction/TransactionContextKeys';
 import { Transaction } from '@/transaction/Transaction';
 import { DatabaseRegistry } from '@/connection/DatabaseRegistry';
-import { Namespace } from 'cls-hooked';
 import { DrivineContext } from '@/context/DrivineContext';
-import * as cls  from 'cls-hooked';
+import { MakeLocalStorage } from '@/utils/LocalStorageFactory';
 
 /**
  * Wrap local storage to make it injectable.
@@ -13,7 +12,7 @@ import * as cls  from 'cls-hooked';
 export class TransactionContextHolder {
     static instance: TransactionContextHolder;
 
-    readonly namespace: Namespace;
+    readonly localStorage = MakeLocalStorage()
 
     static getInstance(): TransactionContextHolder {
         if (!TransactionContextHolder.instance) {
@@ -27,63 +26,44 @@ export class TransactionContextHolder {
         delete TransactionContextHolder.instance;
     }
 
-    constructor() {
-        const namespaceName = '__transaction_context_holder__';
-        this.namespace = cls.getNamespace(namespaceName) || cls.createNamespace(namespaceName);
-    }
-
     run(fn: (...args: any[]) => void): void {
-        return this.namespace.run(fn);
+        return this.localStorage.run(fn);
     }
 
     runAndReturn<T>(fn: (...args: any[]) => T): T {
-        return this.namespace.runAndReturn(fn);
+        return this.localStorage.runAndReturn(fn);
     }
 
     async runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T> {
-        return this.namespace.runPromise(fn);
+        return this.localStorage.runPromise(fn);
     }
 
     get drivineContext(): DrivineContext | undefined {
-        return this.get<DrivineContext | undefined>(TransactionContextKeys.DRIVINE_CONTEXT);
+        return this.localStorage.get<DrivineContext | undefined>(TransactionContextKeys.DRIVINE_CONTEXT);
     }
 
     set drivineContext(context: DrivineContext | undefined) {
-        this.set<DrivineContext | undefined>(TransactionContextKeys.DRIVINE_CONTEXT, context);
+        this.localStorage.set<DrivineContext | undefined>(TransactionContextKeys.DRIVINE_CONTEXT, context);
     }
 
     get currentTransaction(): Transaction | undefined {
-        return this.get<Transaction>(TransactionContextKeys.TRANSACTION);
+        return this.localStorage.get<Transaction>(TransactionContextKeys.TRANSACTION);
     }
 
     set currentTransaction(transaction: Transaction | undefined) {
-        this.set<Transaction | undefined>(TransactionContextKeys.TRANSACTION, transaction);
+        this.localStorage.set<Transaction | undefined>(TransactionContextKeys.TRANSACTION, transaction);
     }
 
     get databaseRegistry(): DatabaseRegistry {
-        return this.get<DatabaseRegistry>(TransactionContextKeys.DATABASE_REGISTRY);
+        return this.localStorage.get<DatabaseRegistry>(TransactionContextKeys.DATABASE_REGISTRY);
     }
 
     set databaseRegistry(registry: DatabaseRegistry) {
-        this.set<DatabaseRegistry>(TransactionContextKeys.DATABASE_REGISTRY, registry);
+        this.localStorage.set<DatabaseRegistry>(TransactionContextKeys.DATABASE_REGISTRY, registry);
     }
 
-    private get<T>(key: string): T {
-        return this.namespace.get(key);
-    }
-
-    private set<T>(key: string, object: T): void {
-        this.namespace.set(key, object);
-    }
-
+   
     private tearDown(): void {
-        /**
-         * Zeroing _contexts as heaviest part of namespace in case we 
-         * have leak and Namespace or ContextHolder is not released, even we manually called "tearDown"
-         */
-        this.namespace['_contexts'] = null;
-
-        const namespaceName = this.namespace['name'];
-        cls.destroyNamespace(namespaceName);
+        this.localStorage.tearDown();
     }
 }

--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -1,0 +1,12 @@
+
+export interface LocalStorage {
+    
+    run(fn: (...args: any[]) => void): void;
+    runAndReturn<T>(fn: (...args: any[]) => T): T;
+    runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T>;
+
+    get<T>(key: string): T;
+    set<T>(key: string, object: T): void;
+
+    tearDown(): void;
+}

--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -1,12 +1,14 @@
 
 export interface LocalStorage {
-    
+   
     run(fn: (...args: any[]) => void): void;
     runAndReturn<T>(fn: (...args: any[]) => T): T;
     runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T>;
 
     get<T>(key: string): T;
     set<T>(key: string, object: T): void;
+
+    isInsideRun(): boolean;
 
     tearDown(): void;
 }

--- a/src/utils/LocalStorageAls.ts
+++ b/src/utils/LocalStorageAls.ts
@@ -1,0 +1,46 @@
+import { LocalStorage } from "./LocalStorage";
+import { AsyncLocalStorage } from 'async_hooks'
+
+export class LocalStorageAls implements LocalStorage {
+    
+    asyncLocalStorage = new AsyncLocalStorage<Map<string, any>>();
+
+    run(fn: (...args: any[]) => void): void {
+        this.asyncLocalStorage.run(new Map(), fn);
+    }
+
+    runAndReturn<T>(fn: (...args: any[]) => T): T {
+        this.asyncLocalStorage.enterWith(new Map());
+        const result = fn();
+        this.asyncLocalStorage.exit(() => {
+            // nothing to do
+        });
+        return result;
+    }
+
+    async runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T> {
+        let result;
+        // types are wrong. It supports Promises: https://nodejs.org/api/async_hooks.html#async_hooks_usage_with_async_await
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises
+        await this.asyncLocalStorage.run(new Map(), async () => {
+            result = await fn();
+            return result;
+        });
+        return result as any;
+    }
+
+    get<T>(key: string): T {
+        return this.asyncLocalStorage.getStore()?.get(key)
+    }
+
+    set<T>(key: string, object: T): void {
+        const store = this.asyncLocalStorage.getStore();
+        // eslint-disable-next-line no-unused-expressions
+        store?.set(key, object);
+    }
+
+    tearDown(): void {
+        this.asyncLocalStorage.disable();
+    }
+
+}

--- a/src/utils/LocalStorageAls.ts
+++ b/src/utils/LocalStorageAls.ts
@@ -29,11 +29,18 @@ export class LocalStorageAls implements LocalStorage {
         return result as any;
     }
 
+    isInsideRun(): boolean {
+        return this.asyncLocalStorage.getStore() !== undefined;
+    }
+
     get<T>(key: string): T {
         return this.asyncLocalStorage.getStore()?.get(key)
     }
 
     set<T>(key: string, object: T): void {
+        if (!this.isInsideRun()) {
+            throw new Error(`Trying to write to LocalStorage outside "run" method. Use LocalStorage inside "run" methods, or check and ignore this write using "isInsideRun()".`)
+        }
         const store = this.asyncLocalStorage.getStore();
         // eslint-disable-next-line no-unused-expressions
         store?.set(key, object);

--- a/src/utils/LocalStorageClsHooked.ts
+++ b/src/utils/LocalStorageClsHooked.ts
@@ -1,14 +1,15 @@
 import { LocalStorage } from "./LocalStorage";
 import { Namespace } from "cls-hooked";
 import * as cls  from 'cls-hooked';
+import { v4 } from 'uuid';
 
 export class LocalStorageClsHooked implements LocalStorage {
 
     readonly namespace: Namespace;
 
     constructor() {
-        const namespaceName = '__transaction_context_holder__';
-        this.namespace = cls.getNamespace(namespaceName) || cls.createNamespace(namespaceName);
+        const namespaceName = `__local_storage_${v4()}__`;
+        this.namespace = cls.createNamespace(namespaceName);
     }
 
     run(fn: (...args: any[]) => void): void {

--- a/src/utils/LocalStorageClsHooked.ts
+++ b/src/utils/LocalStorageClsHooked.ts
@@ -23,6 +23,10 @@ export class LocalStorageClsHooked implements LocalStorage {
         return this.namespace.runPromise(fn);
     }
 
+    isInsideRun(): boolean {
+        return !!this.namespace.active;
+    }
+
     get<T>(key: string): T {
         return this.namespace.get(key);
     }

--- a/src/utils/LocalStorageClsHooked.ts
+++ b/src/utils/LocalStorageClsHooked.ts
@@ -1,0 +1,45 @@
+import { LocalStorage } from "./LocalStorage";
+import { Namespace } from "cls-hooked";
+import * as cls  from 'cls-hooked';
+
+export class LocalStorageClsHooked implements LocalStorage {
+
+    readonly namespace: Namespace;
+
+    constructor() {
+        const namespaceName = '__transaction_context_holder__';
+        this.namespace = cls.getNamespace(namespaceName) || cls.createNamespace(namespaceName);
+    }
+
+    run(fn: (...args: any[]) => void): void {
+        return this.namespace.run(fn);
+    }
+
+    runAndReturn<T>(fn: (...args: any[]) => T): T {
+        return this.namespace.runAndReturn(fn);
+    }
+
+    async runPromise<T>(fn: (...args: any[]) => Promise<T>): Promise<T> {
+        return this.namespace.runPromise(fn);
+    }
+
+    get<T>(key: string): T {
+        return this.namespace.get(key);
+    }
+
+    set<T>(key: string, object: T): void {
+        this.namespace.set(key, object);
+    }
+
+    tearDown(): void {
+        /*
+         * Zeroing _contexts as heaviest part of namespace in case we 
+         * have leak and Namespace or ContextHolder is not released, even we manually called "tearDown"
+         */
+        this.namespace['_contexts'] = null;
+
+        const namespaceName = this.namespace['name'];
+        cls.destroyNamespace(namespaceName);
+    }
+
+}

--- a/src/utils/LocalStorageFactory.ts
+++ b/src/utils/LocalStorageFactory.ts
@@ -1,0 +1,29 @@
+import { LocalStorage } from "./LocalStorage";
+import { LocalStorageAls } from "./LocalStorageAls";
+import { LocalStorageClsHooked } from "./LocalStorageClsHooked";
+
+function isAlsSupported(): boolean {
+    const [nodeMajor, nodeMinor] = process.versions.node.split('.');
+
+    const major = Number.parseInt(nodeMajor);
+    const minor = Number.parseInt(nodeMinor);
+
+    if (major === 12 && minor >= 17) {
+        return true;
+    }
+
+    if (major === 13 && minor >= 10) {
+        return true;
+    }
+
+    return major > 13;
+}
+
+
+export function MakeLocalStorage(): LocalStorage {
+    if (isAlsSupported()) {
+        return new LocalStorageAls();
+    } else {
+        return new LocalStorageClsHooked();
+    }
+}


### PR DESCRIPTION
This is probably not very concise and clear implementation.. but it works very well on my project. 
Implementation is highly inspired by https://github.com/kibertoad/asynchronous-local-storage, but has some fixes.

I'll just leave it as PR.

When cls-hooked implementation used, there is one change in logic, compared to original drivine implementation:
In original implementation `TransactionContextHolder` gets namespace by name, or creates if not exists.
In my implementation `TransactionContextHolder` always creates a namespace. But as `TransactionContextHolder` is a singletone, it shouldn't change anything, as it would be created once per process.

I changed that to have same logic on both "cls-hooked" and "als" implementations.