### PR TITLE
introduced new ConnectionProperties "protocol" 

### DIFF
--- a/src/connection/ConnectionProperties.ts
+++ b/src/connection/ConnectionProperties.ts
@@ -10,6 +10,7 @@ export interface ConnectionProperties {
     idleTimeout?: number;
     databaseName?: string;
     defaultGraphPath?: string;
+    protocol?: string;
 }
 
 /**

--- a/src/connection/ConnectionProviderBuilder.ts
+++ b/src/connection/ConnectionProviderBuilder.ts
@@ -17,6 +17,7 @@ export class ConnectionProviderBuilder {
     private _port?: number;
     private _userName?: string;
     private _password?: string;
+    private _protocol?: string;
 
     // AgensGraph properties
     private _idleTimeout?: number;
@@ -38,6 +39,7 @@ export class ConnectionProviderBuilder {
         this._idleTimeout = properties.idleTimeout;
         this._name = properties.databaseName;
         this._defaultGraphPath = properties.defaultGraphPath;
+        this._protocol = properties.protocol;
         return this;
     }
 
@@ -64,6 +66,11 @@ export class ConnectionProviderBuilder {
 
     password(password: string): this {
         this._password = password;
+        return this;
+    }
+
+    protocol(protocol: string): this {
+        this._protocol = protocol;
         return this;
     }
 
@@ -149,6 +156,7 @@ export class ConnectionProviderBuilder {
             this._port,
             this._userName!,
             this._password,
-            this._name);
+            this._name,
+            this._protocol);
     }
 }

--- a/src/connection/Neo4jConnectionProvider.ts
+++ b/src/connection/Neo4jConnectionProvider.ts
@@ -18,10 +18,11 @@ export class Neo4jConnectionProvider implements ConnectionProvider {
         readonly port: number,
         readonly user: string,
         readonly password: string | undefined,
-        readonly database: string | undefined
+        readonly database: string | undefined,
+        readonly protocol: string = "bolt",
     ) {
         const authToken = neo.auth.basic(this.user, this.password!);
-        this.driver = neo.driver(`bolt://${this.host}:${this.port}`, authToken);
+        this.driver = neo.driver(`${this.protocol}://${this.host}:${this.port}`, authToken);
     }
 
     async connect(): Promise<Connection> {


### PR DESCRIPTION
… to be used in Neo4jConnectionProvider.ts due to breaking change in uri scheme.
see: https://neo4j.com/docs/migration-guide/4.0/upgrade-driver/#upgrade-driver-breakingchanges

Unfortunately i could not make the tests work. it looked like some manual setup was necessary. if you could provide some hint i will have a look at that. 