### PR TITLE
Fix(decorators): InjectCypher path normalization

### DIFF
--- a/src/DrivineInjectionDecorators.ts
+++ b/src/DrivineInjectionDecorators.ts
@@ -1,4 +1,5 @@
 import { Inject } from '@nestjs/common';
+import { join } from 'path';
 
 export const persistenceManagerInjections: string[] = [];
 export const InjectPersistenceManager = (database: string = 'default'): any => {
@@ -48,7 +49,7 @@ export const InjectSql = (dirNameOrPath: string, resource?: string): any => {
  */
 function fileNameFor(dirNameOrPath: string, extension?: string, resourceName?: string): string {
     if (resourceName) {
-        const path = `${dirNameOrPath}/${resourceName}`;
+        const path = join(`${dirNameOrPath}/${resourceName}`);
         return require.resolve(extension ? `${path}.${extension}` : `${path}`);
     } else {
         return require.resolve(extension ? `${dirNameOrPath}.${extension}` : `${dirNameOrPath}`);


### PR DESCRIPTION
While dealing with Drivine, `InjectCyper` decorator, I have noticed, that the path delimiter is hardcoded. Which gives me the following error:
```ts
Error: Cannot find module 'C:\Projects\alexzedim\conglomerat\dist\apps\oraculum/createEntity.cypher'
Require stack:
```

This fix adds `join` method from native node.js `path`  and fix this issue.