### PR TITLE
Fixed issue with Transaction when Promise.all is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@liberation-data/drivine",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@liberation-data/drivine",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "license": "LGPL-3.0-or-later or Apache-2.0",
             "dependencies": {
                 "async-mutex": "^0.4.0",

--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -71,9 +71,9 @@ export class Transaction {
         return Promise.resolve();
     }
 
-    async popContext(): Promise<void> {
+    async popContext(isRoot: boolean): Promise<void> {
         this.callStack.pop();
-        if (this.callStack.isEmpty()) {
+        if (isRoot) {
             this.logger.verbose(`Closing ${this.cursors.length} open cursors.`);
             await Promise.all(this.cursors.map(async (it) => it.close()));
             if (this.options.rollback) {
@@ -89,12 +89,9 @@ export class Transaction {
         }
     }
 
-    async popContextWithError(e: Error): Promise<void> {
-        if (this.callStack.isEmpty()) {
-            throw e;
-        }
+    async popContextWithError(e: Error, isRoot: boolean): Promise<void> {
         this.callStack.pop();
-        if (this.callStack.isEmpty()) {
+        if (isRoot) {
             this.logger.verbose(`Rolling back transaction: ${this.description} due to error: ${e.message}.`);
             await Promise.all(this.connections.map(async (it) => it.rollbackTransaction()));
             await this.releaseClient(e);

--- a/src/transaction/Transactional.ts
+++ b/src/transaction/Transactional.ts
@@ -31,14 +31,14 @@ export async function runInTransaction(
     const options = optionsWithDefaults(transactionOptions);
     const contextHolder = TransactionContextHolder.getInstance();
     const transaction = contextHolder.currentTransaction || new Transaction(options, contextHolder);
-
+    const isRoot = transaction.callStack.isEmpty()
     try {
         await transaction.pushContext(fn.name || `[anonymous function]`);
         const result = await fn(...args);
-        await transaction.popContext();
+        await transaction.popContext(isRoot);
         return result;
     } catch (e) {
-        await transaction.popContextWithError(e as Error);
+        await transaction.popContextWithError(e as Error, isRoot);
         throw e;
     }
 }


### PR DESCRIPTION
I discovered issue when we use `Promise.all` inside `@Transactional` method, and one of promises get rejected.
In that case, when we leave `@Transactional` method, the stack is not empty, hence transaction is not rolled back. Instead it's committed after all Promises inside are complete..

See a small illustration of the issue:

```typescript

@Transactional()
async root(): Promise<void> {
   await Promise.all([this.thread1(), this.thread2()])
}

async thread1(): Promise<void> {
  await work()
}

async thread2(): Promise<void> {
   await work2()
   throw new Error('rejected')
}

```

<img width="773" alt="Screenshot 2023-10-12 at 21 13 33" src="https://github.com/liberation-data/drivine/assets/2268687/e6e9e4f3-9393-4acf-a053-be2dd6f1aee8">

So in this case once `thread2` is failed and returned to `root` as exception, `thread1` is keep working. We are checking for a Stack there, but stack is not empty (as Thread1 added it's items to stack). In result: the error is ignored and both thread1 and thread2 data is committed in the transaction.

The proposed fix is to store `callStack.isEmpty` as `isRoot` flag inside `Transactional` **before** running a function. Then we can identify a root Transactional case, and commit/rollback transaction there. That way `Promise.all` and other pseudo parallel children wouldn't affect that flag: once parent `@Transactional` method is exited - transaction is either committed or rolled back.

